### PR TITLE
Update coco_evaluation.py

### DIFF
--- a/coco_evaluation.py
+++ b/coco_evaluation.py
@@ -52,16 +52,17 @@ def getDetections(groundtruth, evaluation, imgIds = [], annIds = [], detection_t
 
 		for gt_box_id in gt_bboxes:
 			gt_box = groundtruth.anns[gt_box_id]['bbox']
-			max_iou = detection_threshold
+			max_iou = 0.0
 			match = None
 			for eval_box_id in eval_bboxes:
 				eval_box = evaluation.anns[eval_box_id]['bbox']
 				iou = iou_score(gt_box,eval_box)
-				if iou > max_iou:
+				if iou >= detection_threshold and iou > max_iou:
+					max_iou = iou
 					match = eval_box_id
-			if match:
-				detectRes['true_positives'].append({'gt_id': gt_box_id, 'eval_id': eval_box_id})
-				eval_bboxes.remove(eval_box_id)
+			if match is not None:
+				detectRes['true_positives'].append({'gt_id': gt_box_id, 'eval_id': match})
+				eval_bboxes.remove(match)
 			else:
 				detectRes['false_negatives'].append({'gt_id': gt_box_id})
 		if len(eval_bboxes)>0:
@@ -125,22 +126,23 @@ def evaluateEndToEnd(groundtruth, evaluation, imgIds = [], annIds = [], detectio
 				continue
 			gt_val = decode(groundtruth.anns[gt_box_id]['utf8_string'])
 
-			max_iou = detection_threshold
+			max_iou = 0.0
 
 			match = None
 			for eval_box_id in eval_bboxes:
 				eval_box = evaluation.anns[eval_box_id]['bbox']
 				iou = iou_score(gt_box,eval_box)
 
-				if iou > max_iou:
+				if iou >=detection_threshold and iou > max_iou:
+					max_iou = iou
 					match = eval_box_id
 					if 'utf8_string' in evaluation.anns[eval_box_id]:
 						eval_val = decode(evaluation.anns[eval_box_id]['utf8_string'])
 						if editdistance.eval(gt_val, eval_val)==0:
 							break
 			if match is not None:
-				detectRes['true_positives'].append({'gt_id': gt_box_id, 'eval_id': eval_box_id})
-				eval_bboxes.remove(eval_box_id)
+				detectRes['true_positives'].append({'gt_id': gt_box_id, 'eval_id': match})
+				eval_bboxes.remove(match)
 			else:
 				detectRes['false_negatives'].append({'gt_id': gt_box_id})
 		if len(eval_bboxes)>0:


### PR DESCRIPTION
In the original script, the matching procedure between ground truth rectangles and detection rectangles is problematic. To be exact, in line 53 to line 66, in each iteration the function seeks the best match for each ground truth rectangle and removes the best match from the list of detection rectangles, if any. However, the one actually removed is NOT the best match, but the last one in the list of detection rectangles, because of this line: eval_bboxes.remove(eval_box_id). Here, match instead of eval_box_id should be used, since eval_box_id becomes the last index after the loop.
